### PR TITLE
SPARK-46992 query consistency when cached (tests)

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -46,6 +46,80 @@ class DatasetCacheSuite extends QueryTest
       == numOfCachesDependedUpon)
   }
 
+  test("SPARK-46992 consistent queryExecution: 'sort(...).sample(...)'") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    val df0 = (1 to 4).toDF("id")
+    val df1 = df0.sort("id").sample(0.4, 123)
+    val df2 = df1.as[Int].map(_ * 2).toDF()
+
+    assert(df1.count() == df1.collect().length,
+      s"non-persisted: ${df1.count()} <> ${df1.collect().length}")
+    assert(df2.count() == df2.collect().length,
+      s"non-persisted: ${df2.count()} <> ${df2.collect().length}")
+    assert(df1.count() == df2.count(),
+      s"non-persisted (count): ${df1.count()} <> ${df2.count()}")
+
+    val dfC = df1.persist(StorageLevel.MEMORY_ONLY)
+    dfC.count()
+    assert(dfC.count() == dfC.collect().length,
+      s"persisted: ${dfC.count()} <> ${dfC.collect().length}")
+    assert(df1.count() == df1.collect().length,
+      s"persisted: ${df1.count()} <> ${df1.collect().length}")
+    assert(df2.count() == df2.collect().length,
+      s"persisted: ${df2.count()} <> ${df2.collect().length}")
+
+    assert(df1.count() == dfC.count(),
+      s"persisted (count): ${df1.count()} <> ${dfC.count()}")
+    assert(df1.count() == df2.count(),
+      s"persisted (count): ${df1.count()} <> ${df2.count()}")
+
+    val planBefore = df2.queryExecution.executedPlan
+    df2.count()
+    val planAfter = df2.queryExecution.executedPlan
+    assert(planBefore eq planAfter, "executedPlan shouldn't be updated without changes")
+
+    dfC.unpersist()
+
+    assert(dfC.count() == dfC.collect().length,
+      s"unpersisted: ${dfC.count()} <> ${dfC.collect().length}")
+    assert(df1.count() == df1.collect().length,
+      s"unpersisted: ${df1.count()} <> ${df1.collect().length}")
+    assert(df2.count() == df2.collect().length,
+      s"unpersisted: ${df2.count()} <> ${df2.collect().length}")
+    assert(df1.count() == df2.count(),
+      s"unpersisted (count): ${df1.count()} <> ${df2.count()}")
+  }
+
+  test("SPARK-46992 consistent queryExecution: multiple branches with persisted children") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    val dfL = (1 to 4).toDF("idL").sort("idL").sample(0.4, 123)
+    val dfR = (1 to 7).toDF("idR").sort("idR").sample(0.4, 123)
+    val df = dfL.join(dfR)
+
+    assert(df.count() == df.collect().length,
+      s"L and R not persisted: ${df.count()} <> ${df.collect().length}")
+
+    dfL.cache().count()
+    assert(df.count() == df.collect().length,
+      s"L persisted: ${df.count()} <> ${df.collect().length}")
+
+    dfR.cache().count()
+    assert(df.count() == df.collect().length,
+      s"L and R persisted: ${df.count()} <> ${df.collect().length}")
+
+    dfR.unpersist()
+    assert(df.count() == df.collect().length,
+      s"L persisted and R unpersisted: ${df.count()} <> ${df.collect().length}")
+
+    dfL.unpersist()
+    assert(df.count() == df.collect().length,
+      s"L unpersisted and R unpersisted: ${df.count()} <> ${df.collect().length}")
+  }
+
   test("get storage level") {
     val ds1 = Seq("1", "2").toDS().as("a")
     val ds2 = Seq(2, 3).toDS().as("b")


### PR DESCRIPTION
A couple of tests to speed up collaboration.